### PR TITLE
Fix FLAGS argument usage and RPC interface error

### DIFF
--- a/dev.py
+++ b/dev.py
@@ -333,4 +333,3 @@ if __name__ == '__main__':
     print()
     print(f'MNEMONIC: {PLAYER_MNEMONIC}')
     print('================================')
-_BROWNIE_CONFIG


### PR DESCRIPTION
- The `dev.py` script was using `extra` key to register extra arguments instead of `FLAGS` argument used in `challenge.py`.
- Since the RPC connection is made through a proxy, the network used in brownie should be done through the proxy too.